### PR TITLE
This simple trick makes case history x100 faster

### DIFF
--- a/database/baseline/1-tables/3-Event.sql
+++ b/database/baseline/1-tables/3-Event.sql
@@ -11,5 +11,7 @@ CREATE TABLE "Event"
   , patch     json
   );
 
+CREATE INDEX ON "Event"(modelId);
+
 GRANT ALL ON "Event" TO carma_db_sync;
 GRANT ALL ON "Event_id_seq" TO carma_db_sync;

--- a/database/baseline/1-tables/5-PartnerCancel.sql
+++ b/database/baseline/1-tables/5-PartnerCancel.sql
@@ -11,5 +11,7 @@ create table "PartnerCancel"
   , comment text not null default ''
   );
 
+CREATE INDEX ON "PartnerCancel"(caseId);
+
 GRANT ALL ON "PartnerCancel" TO carma_db_sync;
 GRANT ALL ON "PartnerCancel_id_seq" TO carma_db_sync;

--- a/database/baseline/3-dictionaries/27-Sms.sql
+++ b/database/baseline/3-dictionaries/27-Sms.sql
@@ -11,6 +11,8 @@ CREATE TABLE "Sms"
   ,foreignId text
   );
 
+CREATE INDEX ON "Sms"(caseRef);
+
 GRANT ALL ON "Sms" TO carma_db_sync;
 GRANT ALL ON "Sms" TO carma_sms;
 GRANT ALL ON "Sms_id_seq" TO carma_db_sync;

--- a/database/baseline/3-dictionaries/63-AvayaEvent.sql
+++ b/database/baseline/3-dictionaries/63-AvayaEvent.sql
@@ -8,5 +8,7 @@ CREATE TABLE "AvayaEvent"
   , callId text
   );
 
+CREATE INDEX ON "AvayaEvent"(currentAction);
+
 GRANT ALL ON "AvayaEvent" TO carma_db_sync;
 GRANT ALL ON "AvayaEvent_id_seq" TO carma_db_sync;

--- a/database/baseline/4-indexes.sql
+++ b/database/baseline/4-indexes.sql
@@ -12,3 +12,9 @@ create index on casetbl using gist(lower(contact_ownerPhone3) gist_trgm_ops) whe
 
 -- VIN search
 create index on contracttbl using gist(lower(carVin) gist_trgm_ops);
+
+-- CaseHistory
+create index on "Sms"(caseRef);
+create index on "Event"(modelId);
+create index on "PartnerCancel"(caseId);
+create index on "AvayaEvent"(currentAction);

--- a/database/patches/1.350.0-faster-case-history.sql
+++ b/database/patches/1.350.0-faster-case-history.sql
@@ -1,0 +1,6 @@
+
+-- These prevent sequential scans in "CaseHistory" view.
+create index on "Sms"(caseRef);
+create index on "Event"(modelId);
+create index on "PartnerCancel"(caseId);
+create index on "AvayaEvent"(currentAction);


### PR DESCRIPTION
Adding a few indexes prevents sequential scans in "CaseHistory" view.