### PR TITLE
Rewrite some slow queries

### DIFF
--- a/srv/src/AppHandlers/CustomSearches.hs
+++ b/srv/src/AppHandlers/CustomSearches.hs
@@ -347,16 +347,16 @@ relevantCases :: AppHandler ()
 relevantCases = do
   Just c <- getParam "caseId"
   rows <- query ([sql|
-    SELECT
-      c2.id::text,
-      to_char(c2.callDate, 'YYYY-MM-DD HH24:MI')
-    FROM casetbl c1, casetbl c2
-    WHERE c1.id = ?
-      AND c2.id <> c1.id
-      AND lower(c1.contractIdentifier) = lower(c2.contractIdentifier)
-      AND length(c2.contractIdentifier) > 4
-    ORDER BY c2.callDate DESC
-    LIMIT 25
+    WITH c1 AS (
+      SELECT
+        c2.id::text,
+        to_char(c2.callDate, 'YYYY-MM-DD HH24:MI') calldate
+      FROM casetbl c1, casetbl c2
+      WHERE c1.id = ?
+        AND c2.id <> c1.id
+        AND lower(c1.contractIdentifier) = lower(c2.contractIdentifier)
+        AND length(c2.contractIdentifier) > 4
+    )
     |]) [c]
   writeJSON $ mkMap ["caseId", "caseDate"] rows
 


### PR DESCRIPTION
@daapp поделился логами медленных запросов за 19-29 апреля. Можно взять кусочек каждого запроса и посчитать как часто они встречаются.

```
grep 'statement:' all.log \
  | sed 's/^.*statement: \(.\{0,35\}\).*$/\1/' \
  | sort | uniq -c | sort -rn \
  > popularity_contest.txt
```

> 14894 SELECT c2.id::text, to_char(c2.call
>  4289     select "Contract".id, "Contract
>  3066 WITH p AS (SELECT (GetPartnerPaymen
>  2206 DELETE FROM vinnie_queue q WHERE EX
>  1648     select "casetbl".id, "casetbl".
>  1534 SELECT c.id, ((date(cs.callDate) <
>  1222 SELECT * FROM
>  1099 WITH towtimes AS ( SELECT max(t.tim
>   255 WITH lastStates as ( SELECT u.id, u
>   119  SELECT c.id::text, to_char(c.ctime
>   102 COPY (SELECT idExternal,isActiveExt
>    89     select "calltbl".id, "calltbl".
>    80 SELECT a.id::text , coalesce(a.case
>    70 select actiontbl.type, count(*) fro
>    57  WITH "alreadyHandled" AS ( SELECT
>    42 COPY (SELECT idExternal,ctimeExtern
>    35 select count(*) from servicetbl, ac
>    35 select count(*) from actiontbl, ser
>    30 WITH currentUser AS (SELECT * FROM
>    25 insert into "Contract" ( vin, make,


А теперь можно посчитать среднее время выполнения каждого типа запросов и
сколько всего времени ушло на выполнение таких запросов за 10 дней.


```
head -n20 popularity_contest.txt | while read p; do
  STAT=`grep -F "${p#* }" all.log | awk '{sum+=$12} END {print "minutes total: " sum/60000 "\tavg: " sum/NR "\tcount: " NR "\t"}'`
  echo "$STAT ${p#* }"
done
```

 - [ ] `total: 608.879	avg: 16560.6	count: 2206	 DELETE FROM vinnie_queue q WHERE EX`
 - [x] `total: 497.984	avg: 2006.11	count: 14894	 SELECT c2.id::text, to_char(c2.call`
 - [ ] `total: 407.437	avg: 5689.13	count: 4297	     select "Contract".id, "Contract`
 - [ ] `total: 87.0145	avg: 4130.43	count: 1264	 SELECT * FROM`
 - [ ] `total: 74.4055	avg: 16596	count: 269	 WITH lastStates as ( SELECT u.id, u`
 - [ ] `total: 69.879	avg: 1367.49	count: 3066	 WITH p AS (SELECT (GetPartnerPaymen`
 - [ ] `total: 50.7263	avg: 1845.71	count: 1649	     select "casetbl".id, "casetbl".`
 - [ ] `total: 50.2756	avg: 1957.52	count: 1541	 SELECT c.id, ((date(cs.callDate) <`
 - [ ] `total: 45.175	avg: 47552.7	count: 57	  WITH "alreadyHandled" AS ( SELECT`
 - [ ] `total: 35.0907	avg: 1915.78	count: 1099	 WITH towtimes AS ( SELECT max(t.tim`
 - [ ] `total: 11.5002	avg: 5798.4	count: 119	  SELECT c.id::text, to_char(c.ctime`
 - [ ] `total: 11.2342	avg: 6544.18	count: 103	 COPY (SELECT idExternal,isActiveExt`
 - [ ] `total: 8.42128	avg: 7218.24	count: 70	 select actiontbl.type, count(*) fro`
 - [ ] `total: 5.64294	avg: 9673.61	count: 35	 select count(*) from servicetbl, ac`
 - [ ] `total: 3.80917	avg: 5194.32	count: 44	 COPY (SELECT idExternal,ctimeExtern`
 - [ ] `total: 3.60992	avg: 2433.66	count: 89	     select "calltbl".id, "calltbl".`
 - [ ] `total: 3.06408	avg: 2298.06	count: 80	 SELECT a.id::text , coalesce(a.case`
 - [ ] `total: 2.80679	avg: 4811.65	count: 35	 select count(*) from actiontbl, ser`
 - [ ] `total: 1.44075	avg: 3457.81	count: 25	 insert into "Contract" ( vin, make,`
 - [ ] `total: 0.595794	avg: 1191.59	count: 30	 WITH currentUser AS (SELECT * FROM`


### DELETE FROM vinnie_queue q WHERE EX
На этот запрос ушло 608 минут (примерно по часу в день). Запускается из tools/vinnie чтобы не вставлять дубликаты контрактов. Видимо запускается по крону. К счастью, он не интерактивный и пользователи не страдают от него явно, но общая нагрузка на БД растёт.


### SELECT c2.id::text, to_char(c2.call
Не самый долгий, но самый частый запрос. Это поиск связанных кейсов.

```
SELECT
    c2.id::text,
    to_char(c2.callDate, 'YYYY-MM-DD HH24:MI')
  FROM casetbl c1, casetbl c2
  WHERE c1.id = '738028'
    AND c2.id <> c1.id
    AND lower(c1.contractIdentifier) = lower(c2.contractIdentifier)
    AND length(c2.contractIdentifier) > 4
  ORDER BY c2.callDate DESC
  LIMIT 25
```

Похоже, что специально под этот запрос был добавлен индекс:
```
casetbl (lower(contractidentifier)) WHERE length(contractidentifier) > 4
```
но, судя по плану, вместо него используется индекс `casetbl(callDate)` для
сортировки.

Можно с помошью материализации CTE явно указать, что сортировка по индексу не
нужна и тогда будет использоваться индекс по `contractIdentifier`.

```
WITH c1 AS (
  SELECT
    c2.id::text,
    to_char(c2.callDate, 'YYYY-MM-DD HH24:MI') calldate
  FROM casetbl c1, casetbl c2
  WHERE c1.id = 347673
    AND c2.id <> c1.id
    AND lower(c1.contractIdentifier) = lower(c2.contractIdentifier)
    AND length(c2.contractIdentifier) > 4
)
SELECT * FROM c1 ORDER BY callDate DESC LIMIT 25;
```
На моём компьютере второй запрос выполняется за 1ms вместо 2s в исходной версии.

### select "Contract".id, "Contract`
Это кусок запроса из поиска по контрактам: https://github.com/ruamk/carma/blob/5d3b0d04faa0ff8134479b036969232e639faed1/srv/src/Snaplet/Search/Contract.hs#L56
В интерфейсе выбираются поля по которым нужно фильтровать контракты и запрос конструируется динамически. Нужно найти популярные комбинации фильтров и  оптимизировать запрос под них.

### SELECT * FROM`
За `SELECT * FROM` скрываются  `get_KPI_utilization` и `get_KPI_userstates` и возможно ещё что-то.                            

### WITH lastStates as ( SELECT u.id, u`

### WITH p AS (SELECT (GetPartnerPaymen`

### select "casetbl".id, "casetbl".`

### SELECT c.id, ((date(cs.callDate) <`
Это поиск контрактов по идентификатору: https://github.com/ruamk/carma/blob/5d3b0d04faa0ff8134479b036969232e639faed1/srv/src/AppHandlers/CustomSearches/Contract.hs#L100

Главная часть запроса в поиске по GIN индексу на `Contract.fts_key` и на первый взгляд не ясно как можно сделать его быстрее.

### WITH "alreadyHandled" AS ( SELECT`
### WITH towtimes AS ( SELECT max(t.tim`
### SELECT c.id::text, to_char(c.ctime`
### COPY (SELECT idExternal,isActiveExt`
### select actiontbl.type, count(*) fro`
### select count(*) from servicetbl, ac`
### COPY (SELECT idExternal,ctimeExtern`
### select "calltbl".id, "calltbl".`
### SELECT a.id::text , coalesce(a.case`
### select count(*) from actiontbl, ser`
### insert into "Contract" ( vin, make,`
### WITH currentUser AS (SELECT * FROM`
