### PR TITLE
Improve carma-http package to connect to remote host and use HTTP headers.

### DIFF
--- a/carma-http/src/Carma/HTTP.hs
+++ b/carma-http/src/Carma/HTTP.hs
@@ -57,7 +57,7 @@ import qualified Data.Text                  as T
 import qualified Data.Text.Encoding         as T
 import qualified Data.Text.Read             as T
 
-import           Network.HTTP
+import           Network.HTTP hiding (getHeaders)
 
 import           Carma.HTTP.Base
 import           Carma.HTTP.Util
@@ -82,6 +82,7 @@ instanceRequest :: String
                 -> CarmaIO (Int, Maybe InstanceData)
 instanceRequest model rid rm row = do
   cp <- getPort
+  headers <- getHeaders
   let uri =
           case rid of
             Just n  -> modelPidURI cp model n
@@ -90,9 +91,9 @@ instanceRequest model rid rm row = do
   rs <- liftIO $ sendHTTP s $
         case row of
           Just payload ->
-              mkRequestWithBody uri rm $
-              Just ("application/json", B8L.unpack $ encode payload)
-          Nothing -> mkRequestWithBody uri rm Nothing
+              mkRequestWithBody uri rm
+                (Just ("application/json", B8L.unpack $ encode payload)) headers
+          Nothing -> mkRequestWithBody uri rm Nothing headers
   inst <- liftIO $ (decode' . B8L.pack) <$> getResponseBody rs
   return $ case rid of
     -- We already know id

--- a/carma-http/src/Carma/HTTP/New.hs
+++ b/carma-http/src/Carma/HTTP/New.hs
@@ -47,7 +47,7 @@ import           Control.Monad.Trans.Reader
 import           Control.Applicative ((<|>))
 import           Control.Exception
 
-import           Network.HTTP
+import           Network.HTTP hiding (getHeaders)
 import qualified Network.HTTP.Types         as H
 
 import           Data.Model
@@ -145,14 +145,16 @@ instanceRequest rid rm row = do
 
   s <- asks snd
 
+  headers <- getHeaders
   rs <-
     liftIO $ sendHTTP s $
       case guard (rm /= GET) >> row of
            Just payload ->
-             mkRequestWithBody uri rm $
-             Just ("application/json", BSL.unpack $ encode payload)
+             mkRequestWithBody uri rm 
+               (Just ("application/json", BSL.unpack $ encode payload))
+               headers
 
-           Nothing -> mkRequestWithBody uri rm Nothing
+           Nothing -> mkRequestWithBody uri rm Nothing headers
 
   inst <- liftIO $ BSL.pack <$> getResponseBody rs
   let isMultiple = rm == GET && isJust row

--- a/carma-http/src/Carma/HTTP/Util.hs
+++ b/carma-http/src/Carma/HTTP/Util.hs
@@ -1,6 +1,5 @@
 module Carma.HTTP.Util
-    (
-      mkRequestWithBody
+    ( mkRequestWithBody
     )
 
 where
@@ -17,12 +16,13 @@ mkRequestWithBody :: String
                   -> RequestMethod
                   -> Maybe (String, String)
                   -- ^ Content-type header value and request body.
+                  -> [Header]
                   -> Request_String
-mkRequestWithBody urlString method payload =
+mkRequestWithBody urlString method payload headers =
   case parseURI urlString of
     Nothing -> error ("mkRequestWithBody: Not a valid URL - " ++ urlString)
     Just u  -> case payload of
                  Just tb -> setRequestBody rq tb
                  Nothing -> rq
                  where
-                   rq = mkRequest method u
+                   rq = Request u method headers ""


### PR DESCRIPTION
Add parameters to connect to remote host.
Able to specify HTTP headers (cookies, for example).