### PR TITLE
Fix/update userstate on new call

### DIFF
--- a/docs/UserState.md
+++ b/docs/UserState.md
@@ -1,0 +1,34 @@
+User states are used to track when operators were busy doing work or idle
+waiting for a call. History of user state changes is stored in the
+[`UserState`](../database/baseline/1-tables/4-UserState.sql)
+table.
+
+There is a [bunch of SQL functions](../database/baseline/2-functions/2-kpis.sql)
+that use this table to calculate various KPIs.
+
+User state change can be triggered by a number of events (grep for `logCRUD*`,
+`updateUserState`:
+  - Directly from createHandler & updateHandler.
+    - User state can be changed when something is created or updated via HTTP API.
+  - Triggers.hs
+    - When a call is created, a new action is also created and linked to it. So we need to trigger user state change on action creation.
+    - Transferring an action causes new action creation. Again, explicit user state update is required.
+  - Backoffice DSL
+    - `closePrevious`: closing related actions.
+    - `openAction`: updating an action with `openTime`.
+  - Avaya
+    - `switchToNA`, `switchToReady`, `forceBusyUserToServiceBreak`.
+
+
+Seems like architecture gone wild here. Would be better to have a single
+place in the processing pipeline where new user states are created.
+
+Current UserState is also planted into user's `Usermeta.stuff` JSON field. Maybe
+this can be replaced with SQL view.
+
+The code in [`Utils.Events`](../srv/src/Utils/Events.hs) is quite complicated
+and calls for refactoring.
+
+
+### Unanswered questions:
+  - what is a `delayedState`?

--- a/srv/src/Utils/Events.hs
+++ b/srv/src/Utils/Events.hs
@@ -286,6 +286,7 @@ nextState lastState' delayed' evt mname patch =
 
     change ([Ready] >>> Busy) $ do
       on Update $ Fields [field Action.openTime]
+      on Create $ Fields [field Action.openTime]
 
     change ([LoggedOut] >>> Ready)     $ on Login  NoModel
     change (allStates   >>> LoggedOut) $ on Logout NoModel


### PR DESCRIPTION
Оператор должен переходить в статус "Занят" при создании нового звонка. (И обратно, при закрытии).