### PR TITLE
Доработка экрана редактирования партнера

### DIFF
--- a/carma-models/src/Carma/Model/Partner.hs
+++ b/carma-models/src/Carma/Model/Partner.hs
@@ -62,6 +62,11 @@ data Partner = Partner
                 "taxScheme"
                 "Форма налогообложения"
 
+  , isKpiEnabled
+             :: F Bool
+                "isKpiEnabled"
+                "Работа по KPI"
+
   , isPayBackConfirmed
              :: F Bool
                 "isPayBackConfirmed"

--- a/carma-models/src/Carma/Model/Partner/Persistent.hs
+++ b/carma-models/src/Carma/Model/Partner/Persistent.hs
@@ -40,6 +40,7 @@ Partner json sql=partnertbl
   emails Value sql=emails
   personInCharge Text Maybe sql=personincharge
   taxScheme TaxSchemeId Maybe sql=taxscheme
+  isKpiEnabled Bool sql=iskpienabled
   isPayBackConfirmed Bool sql=ispaybackconfirmed
   foreignIdent Text Maybe sql=foreignident
   mtime UTCTime sql=mtime

--- a/database/patches/1.354.0-add-partner_isKpiEnabled.sql
+++ b/database/patches/1.354.0-add-partner_isKpiEnabled.sql
@@ -1,0 +1,5 @@
+alter table partnertbl add column isKpiEnabled bool not null default false;
+
+insert into "FieldPermission" (role, model, field, r, w) values
+  (1, 'Partner', 'isKpiEnabled', true, false)
+, (3, 'Partner', 'isKpiEnabled', true, true);

--- a/srv/resources/assets/script/dictionaries/computed-dict.coffee
+++ b/srv/resources/assets/script/dictionaries/computed-dict.coffee
@@ -160,6 +160,19 @@ class ComputedDict extends ld.dict
     @colors = _.reduce vals, ((m, [_, c], k) -> m[k] = c), {}
     @source = _.map vals, ([v, c], k) -> {label: v, value: k, color: c}
 
+  PartnerIsActive: =>
+    @source = [ {label: "Все",       value: "all"}
+              , {label: "Активен",   value: "yes"}
+              , {label: "Неактивен", value: "no"}
+              ]
+
+  PartnerType: =>
+    @source = [ {label: "Все",               value: "all"}
+              , {label: "Дилер",             value: "dealer"}
+              , {label: "Партнёр",           value: "partner"}
+              , {label: "Мобильный партнёр", value: "mobile"}
+              ]
+
 module.exports =
   dict: ComputedDict
   name: 'ComputedDict'

--- a/srv/resources/assets/template/screens/partner.pug
+++ b/srv/resources/assets/template/screens/partner.pug
@@ -1,20 +1,38 @@
+mixin filterDict(name, placeholder)
+  .input-group.input-group-sm
+    input.form-control(type="text"
+       autocomplete="off"
+       placeholder=`${placeholder}`
+       data-bind=`\n\
+                  value: ${name}.local,\
+                  valueUpdate: 'change',\
+                  bindDict: '${name}'`)
+    span.input-group-addon
+      span.glyphicon.glyphicon-chevron-down
+
 .screen.container-fluid.row
   #partner-left.col.col-md-6
-    form.form-vertical
-      button.btn.btn-action(type='button'
-          onclick="location.hash='partner';location.reload(true);")
-        span.glyphicon.glyphicon-plus
-        | Добавить партнёра
-      br
-      br
-      table#partner-table.table.table-striped.table-bordered
-        thead
-          tr
-            th #
-            th Название
-            th Город
-            th Комментарии
-        tbody
+    #partner-table-filters.form-inline
+      .col-sm-4
+        +filterDict('isActive', 'Активность')
+      .col-sm-4
+        +filterDict('partnerType', 'Тип партнёра')
+      .col-sm-4
+        button.btn.btn-action(type='button'
+            onclick="location.hash='partner';location.reload(true);")
+          span.glyphicon.glyphicon-plus
+          | &nbsp; Добавить партнёра
+    br
+    table#partner-table.table.table-striped.table-bordered
+      thead
+        tr
+          th Скрытая колонка для фильтра
+          th Скрытая колонка для фильтра
+          th #
+          th Название
+          th Город
+          th Комментарии
+      tbody
 
   #partner-center.col.col-md-6
     form.form-horizontal


### PR DESCRIPTION
Необходимо добавить два фильтра на экране редактирования партнеров

- Фильтр по активности (например: выпадающий список «Все/Активен/Неактивен»)
- Фильтр по типу партнера (например: выпадающий список «Все/Дилер/Партнер/Мобильный партнер»)

Необходимо добавить флаговое поле «Работа по KPI» (и колонку в таблицу partnertable) в карточку партнера. Предположительно ниже/выше флагового поля «Соглашение о вознаграждении».
